### PR TITLE
Explicitly prepare the rockchip uboot hosttools before the install task

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip.bbappend
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip.bbappend
@@ -29,4 +29,4 @@ do_prepare_host_tools() {
 
 FILES:${PN} = "/boot"
 
-addtask do_prepare_host_tools after do_compile
+addtask do_prepare_host_tools after do_compile before do_install


### PR DESCRIPTION
Without running the task before install, it happened that the tools binaries were already cleaned up.

Fixes #2 