### PR TITLE
Constrain task order in u-boot-rockchip-bootscript.bb to prevent ooo execution

### DIFF
--- a/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip-bootscript.bb
+++ b/meta-picocalc-bsp-rockchip/recipes-bsp/u-boot/u-boot-rockchip-bootscript.bb
@@ -28,7 +28,7 @@ python do_create_boot_scr_sh() {
     with open(d.getVar("UBOOT_BOOTSCR_TEMPLATE"), "r") as f:
         bootScrTemplate = f.read()
 
-    bootScrPath = oe.path.join(d.getVar("UNPACKDIR"), "boot.scr.sh")
+    bootScrPath = d.getVar("UBOOT_BOOTSCR")
 
     args = {
     }
@@ -61,8 +61,8 @@ do_deploy() {
     install -D -m 0644 ${UBOOT_BOOTSCR_IMG} ${DEPLOYDIR}/boot.scr
 }
 
-addtask do_deploy after do_compile
-addtask do_create_boot_scr_sh before do_compile
+addtask do_deploy after do_compile before do_install
+addtask do_create_boot_scr_sh before do_compile after do_configure
 
 FILES:${PN} += "/boot"
 


### PR DESCRIPTION
Without this additional constraint, `do_create_boot_scr_sh` was being scheduled as the first task in the recipe in my build environment. This change along with #5 was necessary to resolve issue #2 for me.  With this, I am able to complete a full build from clean.

